### PR TITLE
Add the advent calendars for 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@
 
 ### アドベントカレンダー
 
+#### 2022
+- [mast Advent Calendar 2022](https://adventar.org/calendars/8006)
+- [klis Advent Calendar 2022](https://adventar.org/calendars/8181)
+
 #### 2021
 
 - [筑波大学 Advent Calendar 2021](https://adventar.org/calendars/6472)

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@
 ### アドベントカレンダー
 
 #### 2022
+
 - [mast Advent Calendar 2022](https://adventar.org/calendars/8006)
 - [klis Advent Calendar 2022](https://adventar.org/calendars/8181)
 


### PR DESCRIPTION
2022年の筑波大学関連のアドベントカレンダーを追加しました。